### PR TITLE
[WIP]Update marginal likelihood for new VAE structure

### DIFF
--- a/notebooks/example-new-structure.ipynb
+++ b/notebooks/example-new-structure.ipynb
@@ -92,7 +92,6 @@
    "source": [
     "import dill\n",
     "input_file = '../data/traindata_US_referral_V1_rm_zero.pkl'\n",
-    "# This file can be downloaded from s3://sdg-credence/data/referral_V1/processed_pkl/traindata_US_referral_V1_rm_zero.pkl\n",
     "with open(input_file, 'rb') as file:\n",
     "    data_input = dill.load(file)\n",
     "data_input.shape"
@@ -112,7 +111,6 @@
     "\n",
     "import dill\n",
     "in_file = '../data/traindata_US_referral_V1_postprocessed_rm_zero_run2.pkl'\n",
-    "# This file can be downloaded from s3://sdg-credence/data/referral_V1/processed_pkl/traindata_US_referral_V1_postprocessed_rm_zero_run2.pkl\n",
     "with open(in_file, 'rb') as file:\n",
     "    data = dill.load(file)\n",
     "data.shape"

--- a/python/t_VAE.py
+++ b/python/t_VAE.py
@@ -283,44 +283,21 @@ class AR_VAE(baseVAE.BaseVAE, LightningModule):
         return self.sample_dataloader
 
     def marginal(self, D, sample=100):
-        T = D.shape[0]
-        X = D.reshape((T, 1, -1))
-        pi = self.encode(X)
-        mu, logvar = pi
-
-        B = X.shape[1]
-        peaks = self.make_peak(T, B)
-        trend = self.make_trend(T, B, 0.005)
-        seasonality_y = self.make_seasonality(T, B, 365)
-        seasonality_m = self.make_seasonality(T, B, 30)
-        w1 = torch.cat((peaks, trend, seasonality_y, seasonality_m), axis=2)
-        loglike = []
-        for t in range(self.lag, T):
-            Xhat = []
-            for i in range(0, sample):
-                z = torch.randn(B, self.latent_dim)
-                result = self.decoder_input(z)
-                w = self.decoder(result)
-                # concatenating w with addition trends (seasonality+peaks+linear)
-                w = torch.cat((w, w1[t, :, :]), axis=1)
-                # concatenating lag terms
-                w = torch.cat([w] + [X[i, :, :] for i in range(t - self.lag, t)], dim=1)
-                s = self.final_layer(w)
-                Xhat.append(s)
-            Xhat = torch.stack(Xhat)[:, 0, :]
-            mu_Xhat = Xhat.mean(axis=0)
-            cov_inv_Xhat = torch.tensor(
-                np.linalg.inv(np.cov(Xhat.T.detach().numpy()))
-            ).float()
-            loglike_t = -0.5 * torch.matmul(
-                (D[t, :] - mu_Xhat).T, torch.matmul(cov_inv_Xhat, (D[t, :] - mu_Xhat))
-            )
-            loglike.append(loglike_t)
-        return torch.sum(torch.tensor(loglike).float())
+        z = (torch.rand(1, sample, self.latent_dim) * 4) - 2
+        s = self.decode(z)
+        Xhat = s.squeeze(axis=0)
+        mu_Xhat = Xhat.mean(axis=0)
+        cov_inv_Xhat = torch.tensor(
+            np.linalg.inv(np.cov(Xhat.T.detach().numpy()))
+        ).float()
+        loglike = -0.5 * torch.matmul(
+            (D - mu_Xhat).T, torch.matmul(cov_inv_Xhat, (D - mu_Xhat))
+        )
+        return loglike
 
     def marginal_log_likelihood(self, X, samples=100):
-        B = X.shape[1]
+        B = X.shape[0]
         loglike = []
         for i in range(B):
-            loglike.append(self.marginal(X[:, i, :], sample=samples))
+            loglike.append(self.marginal(X[i, :], sample=samples))
         return loglike

--- a/python/t_VAE.py
+++ b/python/t_VAE.py
@@ -24,7 +24,9 @@ class AR_VAE(baseVAE.BaseVAE, LightningModule):
         X: Array,  # shape (T x B x N) (batch size, sequence length, dimensionality)
         latent_dim: int,  # size of the latent dimension
         kld_weight: float = 1,  # weight for KL loss in loss
+        lr: float = 0.005,  # learning rate
         weight_decay: float = 0,  # weight decay
+        hidden_dims: List = None,  # list of hidden dimensions for encoder
         **kwargs
     ) -> None:
         super(AR_VAE, self).__init__()

--- a/python/t_VAE.py
+++ b/python/t_VAE.py
@@ -24,9 +24,7 @@ class AR_VAE(baseVAE.BaseVAE, LightningModule):
         X: Array,  # shape (T x B x N) (batch size, sequence length, dimensionality)
         latent_dim: int,  # size of the latent dimension
         kld_weight: float = 1,  # weight for KL loss in loss
-        lr: float = 0.005,  # learning rate
         weight_decay: float = 0,  # weight decay
-        hidden_dims: List = None,  # list of hidden dimensions for encoder
         **kwargs
     ) -> None:
         super(AR_VAE, self).__init__()
@@ -261,44 +259,21 @@ class AR_VAE(baseVAE.BaseVAE, LightningModule):
         return self.sample_dataloader
 
     def marginal(self, D, sample=100):
-        T = D.shape[0]
-        X = D.reshape((T, 1, -1))
-        pi = self.encode(X)
-        mu, logvar = pi
-
-        B = X.shape[1]
-        peaks = self.make_peak(T, B)
-        trend = self.make_trend(T, B, 0.005)
-        seasonality_y = self.make_seasonality(T, B, 365)
-        seasonality_m = self.make_seasonality(T, B, 30)
-        w1 = torch.cat((peaks, trend, seasonality_y, seasonality_m), axis=2)
-        loglike = []
-        for t in range(self.lag, T):
-            Xhat = []
-            for i in range(0, sample):
-                z = torch.randn(B, self.latent_dim)
-                result = self.decoder_input(z)
-                w = self.decoder(result)
-                # concatenating w with addition trends (seasonality+peaks+linear)
-                w = torch.cat((w, w1[t, :, :]), axis=1)
-                # concatenating lag terms
-                w = torch.cat([w] + [X[i, :, :] for i in range(t - self.lag, t)], dim=1)
-                s = self.final_layer(w)
-                Xhat.append(s)
-            Xhat = torch.stack(Xhat)[:, 0, :]
-            mu_Xhat = Xhat.mean(axis=0)
-            cov_inv_Xhat = torch.tensor(
-                np.linalg.inv(np.cov(Xhat.T.detach().numpy()))
-            ).float()
-            loglike_t = -0.5 * torch.matmul(
-                (D[t, :] - mu_Xhat).T, torch.matmul(cov_inv_Xhat, (D[t, :] - mu_Xhat))
-            )
-            loglike.append(loglike_t)
-        return torch.sum(torch.tensor(loglike).float())
+        z = (torch.rand(1, sample, self.latent_dim) * 4) - 2
+        s = self.decode(z)
+        Xhat = s.squeeze(axis=0)
+        mu_Xhat = Xhat.mean(axis=0)
+        cov_inv_Xhat = torch.tensor(
+            np.linalg.inv(np.cov(Xhat.T.detach().numpy()))
+        ).float()
+        loglike = -0.5 * torch.matmul(
+            (D - mu_Xhat).T, torch.matmul(cov_inv_Xhat, (D - mu_Xhat))
+        )
+        return loglike
 
     def marginal_log_likelihood(self, X, samples=100):
-        B = X.shape[1]
+        B = X.shape[0]
         loglike = []
         for i in range(B):
-            loglike.append(self.marginal(X[:, i, :], sample=samples))
+            loglike.append(self.marginal(X[i, :], sample=samples))
         return loglike


### PR DESCRIPTION
We updated credence’s structure where previous version have one latent space per time step vs the new structure’s latent space doesn’t depend on time t (we use one latent value to infer the whole time series). And thus we created a branch of credence_new_structure. Because of the structural change, many of the functions need to be updated, e.g. the marginal likelihood function. For this specific PR, it’s pretty much WIP and looking for initial feedback of the overall logic/math to the log likelihood calculation and thus no tests have added yet. 